### PR TITLE
Add collaborator access check to RAV4 photo submission workflow

### DIFF
--- a/.github/workflows/process-rav.yml
+++ b/.github/workflows/process-rav.yml
@@ -11,6 +11,19 @@ jobs:
       contents: write
       issues: write
     steps:
+      - name: Check collaborator access
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          STATUS=$(gh api repos/${{ github.repository }}/collaborators/${{ github.event.issue.user.login }} \
+            --silent -i 2>&1 | head -1 | awk '{print $2}')
+          if [ "$STATUS" != "204" ]; then
+            gh issue comment ${{ github.event.issue.number }} \
+              --body "Sorry, only collaborators can submit RAV4 photos."
+            gh issue close ${{ github.event.issue.number }}
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
 
       - uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary
Added a security check to the RAV4 photo submission workflow to restrict submissions to repository collaborators only.

## Key Changes
- Added a new workflow step that validates the issue author has collaborator access before processing RAV4 photo submissions
- The check uses the GitHub API to verify collaborator status (HTTP 204 response indicates access)
- If the user is not a collaborator:
  - A comment is posted to the issue explaining the restriction
  - The issue is automatically closed
  - The workflow exits with an error status

## Implementation Details
- Uses `gh api` to query the collaborators endpoint with the `--silent` flag to suppress output
- Extracts the HTTP status code from the response headers to determine access level
- Placed as the first step in the workflow to fail fast before any processing occurs
- Leverages the existing `GITHUB_TOKEN` secret for API authentication

https://claude.ai/code/session_01AtrWcE5VoswycVto3JuEUa